### PR TITLE
add resource requests to go with limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ recommended if your service is taking production traffic!
 
 1. Change to the service you would like to develop: `cd search`
 
-2. Edit app.py and add debug=True to enable file watch/reload.
+2. Edit `app.py` and change the `app.run` command to enable hot reload: `app.run(host="0.0.0.0", port=8080, debug=True)`.
 
 3. Run: `telepresence --expose 8080 -s search` (this will start a shell)
 

--- a/auth/k8s/deployment.yaml
+++ b/auth/k8s/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{service.name}}
         resources:
+          requests:
+            memory: 0.25G
+            cpu: 0.1
           limits:
             memory: {{service.memory}}
             cpu: {{service.cpu}}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{service.name}}
         resources:
+          requests:
+            memory: 0.25G
+            cpu: 0.1
           limits:
             memory: {{service.memory}}
             cpu: {{service.cpu}}

--- a/search/k8s/deployment.yaml
+++ b/search/k8s/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{service.name}}
         resources:
+          requests:
+            memory: 0.25G
+            cpu: 0.1
           limits:
             memory: {{service.memory}}
             cpu: {{service.cpu}}

--- a/tasks/k8s/deployment.yaml
+++ b/tasks/k8s/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{service.name}}
         resources:
+          requests:
+            memory: 0.25G
+            cpu: 0.1
           limits:
             memory: {{service.memory}}
             cpu: {{service.cpu}}


### PR DESCRIPTION
Current deployment files only specify limits, not requests. This creates a situation where k8s thinks the minimum resources required is the same as the limits, causing lots of deployments to fail because of insufficient CPU/memory.

The reason they fail is because sometimes system daemons or other pods running on your cluster may be consuming CPU/memory such that it's impossible to allocate the CPU/memory specified in the limit to the pod -- but the pod actually has minimum requirements that should allow it to deploy. (See the allocation algorithm here: https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/algorithm/predicates/predicates.go).

In this PR, we create resource requests that are considerably lower than the limits.

